### PR TITLE
Add dynamic port allocation for parallel test sessions

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,9 +3,9 @@
   "version": "1.0.0",
   "description": "Time Scheduler - Timezone comparison web app",
   "scripts": {
-    "test": "playwright test && node scripts/report-coverage.mjs",
-    "test:ui": "playwright test --ui",
-    "test:headed": "playwright test --headed",
+    "test": "PORT=$(node scripts/get-free-port.mjs) playwright test && node scripts/report-coverage.mjs",
+    "test:ui": "PORT=$(node scripts/get-free-port.mjs) playwright test --ui",
+    "test:headed": "PORT=$(node scripts/get-free-port.mjs) playwright test --headed",
     "serve": "serve -l 3000 -s ."
   },
   "devDependencies": {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,5 +1,8 @@
 import { defineConfig, devices } from '@playwright/test';
 
+// Use PORT env var (set by npm test scripts) to avoid conflicts when multiple test sessions run in parallel
+const port = Number(process.env.PORT) || 3000;
+
 export default defineConfig({
   testDir: './tests',
   fullyParallel: true,
@@ -8,7 +11,7 @@ export default defineConfig({
   workers: process.env.CI ? 1 : undefined,
   reporter: 'html',
   use: {
-    baseURL: 'http://localhost:3000',
+    baseURL: `http://localhost:${port}`,
     trace: 'on-first-retry',
   },
   projects: [
@@ -28,8 +31,8 @@ export default defineConfig({
     },
   ],
   webServer: {
-    command: 'npx serve -l 3000 -s .',
-    port: 3000,
+    command: `npx serve -l ${port} -s .`,
+    port,
     reuseExistingServer: !process.env.CI,
   },
 });

--- a/scripts/get-free-port.mjs
+++ b/scripts/get-free-port.mjs
@@ -1,0 +1,7 @@
+import { createServer } from 'net';
+
+const server = createServer();
+server.listen(0, () => {
+  process.stdout.write(String(server.address().port));
+  server.close();
+});

--- a/scripts/report-coverage.mjs
+++ b/scripts/report-coverage.mjs
@@ -28,7 +28,7 @@ for (const file of files) {
 
   for (const entry of entries) {
     // Only include coverage from the app itself
-    if (!entry.url.includes('localhost:3000')) continue;
+    if (!entry.url.includes('localhost:')) continue;
     if (!entry.source) continue;
 
     const converter = v8toIstanbul(appFilePath, 0, {


### PR DESCRIPTION
Enables multiple Playwright test sessions to run in parallel by using dynamically allocated ports instead of a hardcoded port 3000. A new utility script finds an available port, which is then passed to Playwright via the PORT environment variable. The Playwright config uses this variable with 3000 as a fallback, and the coverage reporter's URL filter was adjusted to work with any port.

This allows developers and CI systems to run tests concurrently without port conflicts.