### PR TITLE
Disable viewport zoom on mobile to prevent double scrolling

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 
 <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
     <title>Time Scheduler</title>
     <style>
         * {
@@ -123,6 +123,7 @@
             border-radius: 6px;
             outline: none;
             cursor: pointer;
+            flex: 1;
         }
 
         .date-picker:focus {


### PR DESCRIPTION
Prevent iOS Safari from auto-zooming into the search input and disable pinch-to-zoom. The grid already handles horizontal scrolling internally, so page-level zoom is not needed. Fixes the issue where tapping into the search box causes two horizontal scrolls: page scroll and grid scroll.